### PR TITLE
Workaround for compatibility with other plugins 

### DIFF
--- a/init.rb
+++ b/init.rb
@@ -15,8 +15,7 @@ Redmine::Plugin.register :redmine_hipchat_per_project do
   requires_redmine version_or_higher: '3.1.0'
 
   project_module :hipchat do
-    permission :view_hipchat_settings, { hipchat: :index }
-    permission :set_hipchat_settings, { hipchat: :save  }
+    permission :manage_hipchat_settings, { hipchat: :save }
   end
   settings default: {}
 end

--- a/lib/redmine_hipchat_per_project/patches/projects_helper_patch.rb
+++ b/lib/redmine_hipchat_per_project/patches/projects_helper_patch.rb
@@ -16,12 +16,14 @@ module RedmineHipchatPerProject
           return tabs unless @project.module_enabled? :hipchat
 
           tabs.push({
-            action:     'index',
+            action:     :manage_hipchat_settings,
             controller: 'hipchat',
             label:      :hipchat_settings_header,
             name:       'hipchat',
             partial:    'hipchat/project_settings'
           })
+
+          tabs.select {|tab| User.current.allowed_to?(tab[:action], @project)}
         end
       end
     end


### PR DESCRIPTION
Redmine Checklists uses the same strategy to extend the project settings tabs.